### PR TITLE
Updated docker-compose to work in production

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       - "15670:15670"
 
   rabbitmq:
+    container_name: rabbitmq
     image: rabbitmq:3.9.13-management
     ports:
       - "5672:5672"


### PR DESCRIPTION
Found this example while searching for a way of getting RabbitMQ working over the Web. The example didnt work on a server until i gave the container a name directly.